### PR TITLE
Update 'use' paths

### DIFF
--- a/glitch-in-the-matrix/Cargo.toml
+++ b/glitch-in-the-matrix/Cargo.toml
@@ -9,6 +9,7 @@ name = "glitch-in-the-matrix"
 readme = "../README.md"
 repository = "https://github.com/eeeeeta/glitch-in-the-matrix"
 version = "0.14.0"
+edition = "2018"
 
 [dependencies]
 failure = "0.1"

--- a/glitch-in-the-matrix/src/media.rs
+++ b/glitch-in-the-matrix/src/media.rs
@@ -1,13 +1,13 @@
 //! Media repository management.
 
 use futures::{self, Future};
-use request::{self, MatrixRequest, MatrixRequestable};
+use crate::request::{self, MatrixRequest, MatrixRequestable};
 use http::Method;
 use std::collections::HashMap;
 use http::header::{HeaderValue, CONTENT_TYPE};
 use types::replies::UploadReply;
 use futures::future::Either;
-use errors::MatrixError;
+use crate::errors::MatrixError;
 
 /// Contains media repository endpoints.
 pub struct Media;

--- a/glitch-in-the-matrix/src/presence.rs
+++ b/glitch-in-the-matrix/src/presence.rs
@@ -1,9 +1,9 @@
 //! Presence management.
 
 use types::content::root::types::Presence;
-use request::{MatrixRequest, MatrixRequestable};
+use crate::request::{MatrixRequest, MatrixRequestable};
 use http::Method;
-use errors::MatrixError;
+use crate::errors::MatrixError;
 use futures::Future;
 
 /// Contains methods relating to `/presence/` endpoints.

--- a/glitch-in-the-matrix/src/profile.rs
+++ b/glitch-in-the-matrix/src/profile.rs
@@ -1,10 +1,10 @@
 //! Profile management.
 
 use types::replies::DisplaynameReply;
-use request::{MatrixRequest, MatrixRequestable};
+use crate::request::{MatrixRequest, MatrixRequestable};
 use http::Method;
 use futures::Future;
-use errors::MatrixError;
+use crate::errors::MatrixError;
 
 /// Contains methods relating to `/profile/` endpoints.
 pub struct Profile;

--- a/glitch-in-the-matrix/src/request.rs
+++ b/glitch-in-the-matrix/src/request.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use http::{Request, Response, Method};
 use futures::future::Either;
-use errors::{MatrixError, MatrixResult};
+use crate::errors::{MatrixError, MatrixResult};
 use types::replies::BadRequestReply;
 use serde_json;
 use percent_encoding::{utf8_percent_encode, DEFAULT_ENCODE_SET};
@@ -25,7 +25,7 @@ pub trait ApiType {
 pub mod apis {
     /// APIs at version r0.
     pub mod r0 {
-        use request::ApiType;
+        use crate::request::ApiType;
         use std::borrow::Cow;
         /// `/_matrix/client/r0`
         pub struct ClientApi;

--- a/glitch-in-the-matrix/src/room.rs
+++ b/glitch-in-the-matrix/src/room.rs
@@ -4,11 +4,11 @@ use types::replies::*;
 use types::messages::Message;
 use types::events::Event;
 use types::content::room::PowerLevels;
-use request::{MatrixRequestable, MatrixRequest};
+use crate::request::{MatrixRequestable, MatrixRequest};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use futures::*;
-use errors::*;
+use crate::errors::*;
 use http::Method;
 
 pub use types::room::Room;

--- a/glitch-in-the-matrix/src/sync.rs
+++ b/glitch-in-the-matrix/src/sync.rs
@@ -2,10 +2,10 @@
 
 use types::sync::*;
 use std::collections::HashMap;
-use request::{MatrixRequest, MatrixRequestable, TypedApiResponse};
-use request::apis::r0::ClientApi;
+use crate::request::{MatrixRequest, MatrixRequestable, TypedApiResponse};
+use crate::request::apis::r0::ClientApi;
 use futures::*;
-use errors::*;
+use crate::errors::*;
 use http::Method;
 use futures::Future;
 

--- a/glitch-in-the-matrix/src/util.rs
+++ b/glitch-in-the-matrix/src/util.rs
@@ -1,6 +1,6 @@
 //! Utility wrappers used internally.
 
-use errors::*;
+use crate::errors::*;
 use types::replies::*;
 use hyper::{Body, StatusCode};
 use hyper::client::Response;

--- a/gm-types/Cargo.toml
+++ b/gm-types/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://github.com/eeeeeta/glitch-in-the-matrix"
 keywords = ["chat", "matrix"]
 license = "CC0-1.0"
 repository = "https://github.com/eeeeeta/glitch-in-the-matrix"
+edition = "2018"
 
 [dependencies]
 serde = "1.0"

--- a/gm-types/src/content/room/mod.rs
+++ b/gm-types/src/content/room/mod.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 pub mod types;
-use messages;
+use crate::messages;
 
 fn tru() -> bool {
     true

--- a/gm-types/src/events.rs
+++ b/gm-types/src/events.rs
@@ -5,7 +5,7 @@ use super::content::{Content, deserialize_content};
 use serde::*;
 use serde_json::Value;
 use serde::de;
-use room::Room;
+use crate::room::Room;
 
 /// Contains optional extra information about the event.
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/gm-types/src/replies.rs
+++ b/gm-types/src/replies.rs
@@ -1,9 +1,9 @@
 //! Replies obtained from calling various API endpoints.
-use room::Room;
-use events::Event;
+use crate::room::Room;
+use crate::events::Event;
 use std::collections::HashMap;
 use serde_json::Value;
-use content::room::Member;
+use crate::content::room::Member;
 
 /// The reply obtained from `/send`.
 #[derive(Deserialize, Clone, Debug)]

--- a/gm-types/src/sync.rs
+++ b/gm-types/src/sync.rs
@@ -1,7 +1,7 @@
 //! Types returned from the `/sync` endpoint.
 use std::collections::HashMap;
-use room::Room;
-use events::{Event, Events};
+use crate::room::Room;
+use crate::events::{Event, Events};
 use std::slice;
 
 /// Counts of unread notifications for a room.


### PR DESCRIPTION
Rust 2018 introduced a small breaking change in the paths for `use`, documented https://rust-lang-nursery.github.io/edition-guide/rust-2018/module-system/path-clarity.html#changes-to-paths

Simply prefix `crate::` to all crate local paths used in code.