### PR TITLE
Upgrade dependencies

### DIFF
--- a/glitch-in-the-matrix/Cargo.toml
+++ b/glitch-in-the-matrix/Cargo.toml
@@ -16,18 +16,15 @@ failure = "0.1"
 failure_derive = "0.1"
 http = "0.1"
 futures = "0.1"
-hyper-openssl = "0.3"
+hyper = "0.12"
+hyper-openssl = "0.7"
 percent-encoding = "1.0"
 serde = "1.0"
 serde_json = "1.0"
 tokio-core = "0.1"
 
-[dependencies.hyper]
-version = ">0.11.3"
-features = ["compat"]
-
 [dependencies.uuid]
-version = "0.6"
+version = "0.7"
 features = ["v4"]
 
 [dependencies.gm-types]

--- a/glitch-in-the-matrix/src/errors.rs
+++ b/glitch-in-the-matrix/src/errors.rs
@@ -10,6 +10,8 @@ macro_rules! derive_from {
          )*
     }
 }
+use failure::Fail;
+
 /// Something Matrixy that can go wrong.
 #[derive(Fail, Debug)]
 #[allow(missing_docs)]
@@ -19,7 +21,7 @@ pub enum MatrixError {
     #[fail(display = "Serialization error: {}", _0)]
     Serde(#[cause] ::serde_json::Error),
     #[fail(display = "Error decoding URI: {}", _0)]
-    UriError(#[cause] ::hyper::error::UriError),
+    UriError(#[cause] ::hyper::http::uri::InvalidUri),
     #[fail(display = "I/O error: {}", _0)]
     Io(#[cause] ::std::io::Error),
     #[fail(display = "OpenSSL error: {}", _0)]
@@ -41,7 +43,7 @@ pub enum MatrixError {
 derive_from!(MatrixError,
              Hyper, ::hyper::error::Error,
              Serde, ::serde_json::Error,
-             UriError, ::hyper::error::UriError,
+             UriError, ::hyper::http::uri::InvalidUri,
              HttpError, ::http::Error,
              InvalidHeaderValue, ::http::header::InvalidHeaderValue,
              Io, ::std::io::Error,

--- a/glitch-in-the-matrix/src/presence.rs
+++ b/glitch-in-the-matrix/src/presence.rs
@@ -5,6 +5,7 @@ use crate::request::{MatrixRequest, MatrixRequestable};
 use http::Method;
 use crate::errors::MatrixError;
 use futures::Future;
+use serde_json::json;
 
 /// Contains methods relating to `/presence/` endpoints.
 pub struct PresenceManagement;

--- a/glitch-in-the-matrix/src/profile.rs
+++ b/glitch-in-the-matrix/src/profile.rs
@@ -10,8 +10,8 @@ use crate::errors::MatrixError;
 pub struct Profile;
 
 impl Profile {
-    /// Get the displayname of a given user ID. This API may be used to fetch the user's own displayname or 
-    /// to query the name of other users; either locally or on remote homeservers. 
+    /// Get the displayname of a given user ID. This API may be used to fetch the user's own displayname or
+    /// to query the name of other users; either locally or on remote homeservers.
     pub fn get_displayname<R: MatrixRequestable>(rq: &mut R, user_id: &str) -> impl Future<Item = DisplaynameReply, Error = MatrixError> {
         MatrixRequest::new_basic(Method::GET, format!("/profile/{}/displayname", user_id))
             .send(rq)

--- a/glitch-in-the-matrix/src/request.rs
+++ b/glitch-in-the-matrix/src/request.rs
@@ -10,7 +10,7 @@ use crate::errors::{MatrixError, MatrixResult};
 use types::replies::BadRequestReply;
 use serde_json;
 use percent_encoding::{utf8_percent_encode, DEFAULT_ENCODE_SET};
-use futures::{self, Future, Poll, Async};
+use futures::{self, Future, Poll, Async, try_ready};
 use std::marker::PhantomData;
 
 /// Describes the type of a Matrix API.
@@ -203,7 +203,7 @@ impl<'a, 'b, 'c> MatrixRequest<'a, HashMap<Cow<'b, str>, Cow<'c, str>>> {
     /// - `meth` and `endpoint` specified
     /// - `body` converted from an iterator over `(T, U)` where T & U implement `Into<Cow<str>>`
     /// - `params` set to an empty hashmap
-    /// - `typ` set to `apis::r0::ClientApi` 
+    /// - `typ` set to `apis::r0::ClientApi`
     pub fn new_with_body<S, T, U, V>(meth: Method, endpoint: S, body: V) -> Self
         where S: Into<Cow<'a, str>>,
               T: Into<Cow<'b, str>>,
@@ -221,7 +221,7 @@ impl<'a, 'b, 'c> MatrixRequest<'a, HashMap<Cow<'b, str>, Cow<'c, str>>> {
     }
 }
 impl<'a, T> MatrixRequest<'a, T> where T: Serialize {
-    /// Like `new_with_body`, but takes a serializable object for `body`. 
+    /// Like `new_with_body`, but takes a serializable object for `body`.
     pub fn new_with_body_ser<S>(meth: Method, endpoint: S, body: T) -> Self
         where S: Into<Cow<'a, str>> {
         Self {

--- a/glitch-in-the-matrix/src/util.rs
+++ b/glitch-in-the-matrix/src/util.rs
@@ -2,8 +2,7 @@
 
 use crate::errors::*;
 use types::replies::*;
-use hyper::{Body, StatusCode};
-use hyper::client::Response;
+use hyper::{Body, StatusCode, Response};
 use serde::de::DeserializeOwned;
 use futures::*;
 use std::marker::PhantomData;
@@ -15,9 +14,9 @@ pub struct ResponseWrapper<T> {
     _ph: PhantomData<T>,
 }
 impl<T: DeserializeOwned> ResponseWrapper<T> {
-    pub fn wrap(r: Response) -> Self {
+    pub fn wrap(r: Response<Body>) -> Self {
         let sc = r.status();
-        let inner = r.body().concat2();
+        let inner = r.into_body().concat2();
         let _ph = PhantomData;
         Self { sc, inner, _ph, }
     }

--- a/gm-types/Cargo.toml
+++ b/gm-types/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://github.com/eeeeeta/glitch-in-the-matrix"
 keywords = ["chat", "matrix"]
 license = "CC0-1.0"
 repository = "https://github.com/eeeeeta/glitch-in-the-matrix"
+edition = "2018"
 
 [dependencies]
 error-chain = "0.12"

--- a/gm-types/Cargo.toml
+++ b/gm-types/Cargo.toml
@@ -8,9 +8,9 @@ homepage = "https://github.com/eeeeeta/glitch-in-the-matrix"
 keywords = ["chat", "matrix"]
 license = "CC0-1.0"
 repository = "https://github.com/eeeeeta/glitch-in-the-matrix"
-edition = "2018"
 
 [dependencies]
+error-chain = "0.12"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
Every dependencies used in the project have been upgraded to their latest versions.

I'm still learning Rust, so please review my changes carefully. I can only attest it builds and the tests runs correctly ;)

The tokio handle isn't used anymore when creating the `HttpsConnector`, a default handle is used instead. I didn't find a satisfying way to reuse this default handle in `MatrixClient::drop`, and the handle provided in `MatrixClient::login` is used instead.

There shouldn't be many breaking changes, except `Request` being replaced by `Request<Body>` (introduced by hyper)